### PR TITLE
[HB-16] window cmd 내 sleep 이후 진행 오류

### DIFF
--- a/nhiss/nhiss_bot.py
+++ b/nhiss/nhiss_bot.py
@@ -87,7 +87,7 @@ class NhissBot:
     time_to_wait_sec = float(delta.total_seconds())
     try:
       while time_to_wait_sec > 0:
-        print('left time seconds: ', time_to_wait_sec)
+        print('left time seconds: ', time_to_wait_sec, flush=True)
         time.sleep(time_to_wait_sec if time_to_wait_sec < 30 else 30)
         time_to_wait_sec -= 30
     except ValueError:

--- a/nhiss/nhiss_bot.py
+++ b/nhiss/nhiss_bot.py
@@ -46,11 +46,13 @@ class NhissBot:
   def __init__(self, operating_system: str, headless: bool=False):
     self.operating_system = operating_system
     chrome_options = webdriver.ChromeOptions()
+
     if headless:
       chrome_options.add_argument("--headless")
       chrome_options.add_argument("--no-sandbox")
       
-    chrome_options.add_argument("--disable-software-rasterizer")
+    chrome_options.add_experimental_option("excludeSwitches", ['enable-logging'])
+    chrome_options.add_argument("--disable-gpu")
     self.driver = webdriver.Chrome(
         service=Service(ChromeDriverManager().install()),
         chrome_options=chrome_options
@@ -84,11 +86,14 @@ class NhissBot:
     delta = target_datetime - cur_kst_time
     time_to_wait_sec = float(delta.total_seconds())
     try:
-      time.sleep(time_to_wait_sec)
+      while time_to_wait_sec > 0:
+        print('left time seconds: ', time_to_wait_sec)
+        time.sleep(time_to_wait_sec if time_to_wait_sec < 30 else 30)
+        time_to_wait_sec -= 30
     except ValueError:
-      print('[HiraBot][TargetTimeError] Target Time must be in the future')
+      print('[HiraBot][TargetTimeError] Target Time must be in the future', flush=True)
       exit(1)
-    print('[HiraBot] Time to activate HiraBot!')
+    print('[HiraBot] Time to activate HiraBot!', flush=True)
 
   def setCredential(self, id, pwd, name):
     self.user_id = id


### PR DESCRIPTION
### 1. 작업 사항
- window cmd 내 예약 시간에 따라 sleep 된 이후 프로세스가 정상적으로 진행되지 않는 문제가 존재합니다.
    - macos에서는 정상적으로 실행 
- buffer flush가 정상적으로 진행되지 않은것으로 보고 sleep을 분할하여 buffer flush 를 진행하는 것으로 수정하였습니다.
    - sleep은 30초 단위로 분할하였습니다.
    - 추가적으로 중간에 삽입된 left time 메세지는 디버깅용으로 활용할 수 있도록 추가하였습니다. (실제로 멈췄는지)

### 2. 추가 작업
- 관련 내용은 공단봇 서버 구성 이후 실행 환경이 통일되면 더 좋은 방향으로 개선할 수 있을 것 같습니다.